### PR TITLE
feat: Policy Sets Management and missing OTEL config 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>OTail</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "OTail",
+  "name": "OTail",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.css
+++ b/src/App.css
@@ -4,19 +4,16 @@
 }
 
 .App-header {
-  background-color: #ffffff;
-  padding: 1rem 0;
-  margin-bottom: 20px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background-color: rgb(251, 251, 250);
+  padding: 1rem 96px;
+  border-bottom: 1px solid rgba(55, 53, 47, 0.16);
 }
 
 .App-header h1 {
   margin: 0;
-  font-size: 1.5rem;
-  color: #1d1d1f;
-  max-width: 1800px;
-  margin: 0 auto;
-  padding: 0 20px;
+  font-size: 1.25rem;
+  color: rgb(55, 53, 47);
+  font-weight: 500;
 }
 
 main {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import './App.css';
 import { ConfigEditor } from './components/ConfigEditor/ConfigEditor';
+import { PolicySetsProvider } from './context/PolicySetsContext';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <h1>OpenTelemetry Tail Sampling Configuration Generator</h1>
-      </header>
-      <main>
-        <ConfigEditor />
-      </main>
+      <PolicySetsProvider>
+        <header className="App-header">
+          <h1>OpenTelemetry Tail Sampling Configuration Generator</h1>
+        </header>
+        <main>
+          <ConfigEditor />
+        </main>
+      </PolicySetsProvider>
     </div>
   );
 }

--- a/src/components/ConfigEditor/ConfigEditor.css
+++ b/src/components/ConfigEditor/ConfigEditor.css
@@ -1,8 +1,11 @@
 .config-editor {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 24px;
+  gap: 32px;
   height: 100%;
+  padding: 32px 64px;
+  max-width: 1600px;
+  margin: 0 auto;
 }
 
 .config-editor-left {
@@ -19,9 +22,10 @@
 
 .config-settings {
   background: white;
-  border-radius: 8px;
-  padding: 20px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-radius: 16px;
+  padding: 24px;
+  border: 1px solid #eaecef;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
 }
 
 .settings-grid {
@@ -58,21 +62,23 @@
 }
 
 .form-field label {
+  font-size: 12px;
+  color: rgb(55, 53, 47);
   font-weight: 500;
-  color: #1d1d1f;
+  margin-bottom: 4px;
 }
 
 .form-field input {
-  padding: 8px 12px;
-  border: 1px solid #d1d1d6;
-  border-radius: 6px;
   font-size: 14px;
+  padding: 4px 8px;
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 3px;
+  width: 100%;
 }
 
 .form-field input:focus {
   outline: none;
-  border-color: #0071e3;
-  box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.2);
+  box-shadow: rgb(15, 15, 15) 0px 0px 0px 1px inset;
 }
 
 h2 {
@@ -110,4 +116,113 @@ h2 {
   .config-editor-right {
     height: 400px;
   }
+}
+
+.settings-section {
+  padding: 24px 0;
+  border-bottom: 1px solid #eaecef;
+}
+
+.settings-section:last-child {
+  border-bottom: none;
+}
+
+.settings-section h2 {
+  margin: 0 0 20px 0;
+  font-size: 18px;
+  font-weight: 500;
+  color: #2c3338;
+}
+
+.save-policy-form {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.save-policy-form .form-field {
+  flex: 1;
+}
+
+.save-policy-form button {
+  margin-top: 21px; /* Aligns with input when there's a label */
+}
+
+.save-policy-form button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.form-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #d1d1d6;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #0071e3;
+  box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.2);
+}
+
+.policy-set-save {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.policy-set-save .policy-card-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.policy-set-save .add-policy-button {
+  margin: 0;
+}
+
+.settings-header {
+  padding-bottom: 20px;
+  border-bottom: 1px solid #e5e5ea;
+  margin-bottom: 20px;
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.header-content .policy-name-text,
+.header-content .policy-name-input {
+  flex: 1;
+}
+
+.header-content .add-policy-button {
+  margin: 0;
+  min-width: 80px;
+}
+
+.save-policy-button {
+  padding: 6px 12px;
+  background: transparent;
+  color: rgb(55, 53, 47);
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 20ms ease-in 0s;
+}
+
+.save-policy-button:hover {
+  background: rgba(55, 53, 47, 0.08);
+}
+
+.save-policy-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 } 

--- a/src/components/ConfigEditor/ConfigEditor.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.tsx
@@ -5,6 +5,9 @@ import { PolicyList } from '../PolicyList/PolicyList';
 import { ConfigViewer } from '../ConfigViewer/ConfigViewer';
 import { createNewPolicy } from '../../utils/policyUtils';
 import { AddPolicyButton } from '../common/AddPolicyButton';
+import { PolicySetsMenu } from '../PolicySets/PolicySetsMenu';
+import { usePolicySets } from '../../context/PolicySetsContext';
+import { EditableTitle } from '../common/EditableTitle';
 import './ConfigEditor.css';
 
 export const ConfigEditor: React.FC = () => {
@@ -13,6 +16,22 @@ export const ConfigEditor: React.FC = () => {
     decisionWait: 10,
     numTraces: 100,
   });
+  const [policySetName, setPolicySetName] = useState('');
+  const { addPolicySet } = usePolicySets();
+
+  const handleSavePolicySet = () => {
+    if (policySetName.trim()) {
+      addPolicySet(policySetName, config.policies);
+      setPolicySetName(''); // Clear the input after saving
+    }
+  };
+
+  const handleImportPolicies = (policies: Policy[]) => {
+    setConfig(prev => ({
+      ...prev,
+      policies: [...prev.policies, ...policies],
+    }));
+  };
 
   const handleAddPolicy = (type: PolicyType) => {
     setConfig(prev => ({
@@ -49,29 +68,49 @@ export const ConfigEditor: React.FC = () => {
 
   return (
     <div className="config-editor">
+      <PolicySetsMenu onImportPolicies={handleImportPolicies} />
       <div className="config-editor-left">
         <div className="config-settings">
-          <h2>General Settings</h2>
-          <div className="settings-grid">
-            <div className="form-field">
-              <label htmlFor="decisionWait">Decision Wait (seconds)</label>
-              <input
-                id="decisionWait"
-                type="number"
-                min="1"
-                value={config.decisionWait}
-                onChange={(e) => handleConfigSettingsChange('decisionWait', Number(e.target.value))}
+          <div className="settings-header">
+            <div className="header-content">
+              <EditableTitle
+                value={policySetName}
+                onChange={setPolicySetName}
+                placeholder="Enter policy set name"
               />
+              <button 
+                className="add-policy-button"
+                onClick={handleSavePolicySet}
+                disabled={!policySetName.trim()}
+              >
+                Save
+              </button>
             </div>
-            <div className="form-field">
-              <label htmlFor="numTraces">Number of Traces</label>
-              <input
-                id="numTraces"
-                type="number"
-                min="1"
-                value={config.numTraces}
-                onChange={(e) => handleConfigSettingsChange('numTraces', Number(e.target.value))}
-              />
+          </div>
+
+          <div className="settings-section">
+            <h2>General Settings</h2>
+            <div className="settings-grid">
+              <div className="form-field">
+                <label htmlFor="decisionWait">Decision Wait (seconds)</label>
+                <input
+                  id="decisionWait"
+                  type="number"
+                  min="1"
+                  value={config.decisionWait}
+                  onChange={(e) => handleConfigSettingsChange('decisionWait', Number(e.target.value))}
+                />
+              </div>
+              <div className="form-field">
+                <label htmlFor="numTraces">Number of Traces</label>
+                <input
+                  id="numTraces"
+                  type="number"
+                  min="1"
+                  value={config.numTraces}
+                  onChange={(e) => handleConfigSettingsChange('numTraces', Number(e.target.value))}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/PolicyCard/PolicyCard.css
+++ b/src/components/PolicyCard/PolicyCard.css
@@ -1,22 +1,65 @@
 .policy-card {
   background: white;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  border: 1px solid #eaecef;
   margin-bottom: 16px;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+}
+
+.policy-card:hover {
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.05);
+  transform: translateY(-1px);
 }
 
 .policy-card-header {
-  padding: 16px;
-  border-bottom: 1px solid #e5e5ea;
+  padding: 16px 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
 }
 
-.policy-card-header:hover {
-  background-color: #f8f8f8;
+.policy-name-input {
+  font-size: 15px;
+  font-weight: 450;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: transparent;
+  width: 200px;
+  color: #2c3338;
+}
+
+.policy-name-input:focus {
+  background: #f8f9fa;
+  outline: none;
+}
+
+.policy-type-badge {
+  background: #f8f9fa;
+  padding: 4px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  color: #57606a;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+}
+
+.remove-policy-button {
+  padding: 6px 12px;
+  background: transparent;
+  color: #57606a;
+  border: 1px solid #eaecef;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.2s ease;
+}
+
+.remove-policy-button:hover {
+  background: #f8f9fa;
+  color: #cf222e;
 }
 
 .policy-card-title {
@@ -24,25 +67,6 @@
   align-items: center;
   gap: 12px;
   flex: 1;
-}
-
-.policy-name-input {
-  font-size: 16px;
-  font-weight: 500;
-  border: 1px solid transparent;
-  padding: 4px 8px;
-  border-radius: 4px;
-  background: transparent;
-  width: 200px;
-}
-
-.policy-type-badge {
-  background: #f2f2f7;
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  color: #666;
-  text-transform: uppercase;
 }
 
 .policy-card-actions {
@@ -68,7 +92,7 @@
 }
 
 .policy-card-content {
-  padding: 16px;
+  padding: 0 20px 20px;
   overflow: hidden;
   transition: max-height 0.3s ease;
 }
@@ -98,21 +122,6 @@
   margin-bottom: 16px;
   font-size: 14px;
   color: #873800;
-}
-
-.remove-policy-button {
-  padding: 8px 16px;
-  background: #ff3b30;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 14px;
-  transition: opacity 0.2s;
-}
-
-.remove-policy-button:hover {
-  opacity: 0.9;
 }
 
 /* Nested policy cards (for composite policies) */

--- a/src/components/PolicyEditors/CompositePolicyEditor.css
+++ b/src/components/PolicyEditors/CompositePolicyEditor.css
@@ -1,46 +1,118 @@
 .composite-policy-editor {
-  padding: 16px;
-  background: #f8f8f8;
-  border-radius: 6px;
-  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
-.operator-selector {
+.config-section {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.config-section h3 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1a1a1a;
+  margin: 0 0 16px 0;
+}
+
+.policy-order-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-bottom: 16px;
+  padding: 8px 12px;
+  background: #f8fafc;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #64748b;
+}
+
+.info-icon {
+  font-style: normal;
 }
 
 .sub-policies {
-  padding-left: 16px;
-  border-left: 2px solid #d1d1d6;
-}
-
-.sub-policies h4 {
-  margin: 0 0 16px 0;
-  color: #1d1d1f;
-}
-
-.value-item {
   display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.policy-item {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+  background: #f8fafc;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+}
+
+.policy-order-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: 8px;
-  align-items: flex-start;
-  margin-bottom: 8px;
 }
 
-.remove-button {
-  padding: 8px 12px;
-  background: #ff3b30;
-  color: white;
-  border: none;
+.policy-order-number {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: #e5e7eb;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #4b5563;
+}
+
+.order-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.order-button {
+  padding: 4px 8px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #4b5563;
+  transition: all 0.2s ease;
+}
+
+.order-button:hover:not(:disabled) {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
+.order-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.policy-content {
+  flex: 1;
+}
+
+.add-policy-select {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #e5e7eb;
   border-radius: 6px;
+  background: #fff;
+  color: #1a1a1a;
   cursor: pointer;
 }
 
-.add-button {
-  padding: 8px 12px;
-  background: #007aff;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  margin-top: 8px;
+.add-policy-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
 } 

--- a/src/components/PolicyEditors/CompositePolicyEditor.tsx
+++ b/src/components/PolicyEditors/CompositePolicyEditor.tsx
@@ -1,22 +1,25 @@
 import React from 'react';
 import { CompositePolicy, Policy, PolicyType } from '../../types/PolicyTypes';
 import { PolicyCard } from '../PolicyCard/PolicyCard';
+import { Input } from '../common/Input';
 import { createNewPolicy } from '../../utils/policyUtils';
 import './CompositePolicyEditor.css';
 
-interface CompositePolicyEditorProps {
+export const CompositePolicyEditor: React.FC<{
   policy: CompositePolicy;
   onUpdate: (policy: CompositePolicy) => void;
-}
+}> = ({ policy, onUpdate }) => {
+  const movePolicy = (fromIndex: number, toIndex: number) => {
+    if (toIndex < 0 || toIndex >= policy.subPolicies.length) return;
 
-export const CompositePolicyEditor: React.FC<CompositePolicyEditorProps> = ({
-  policy,
-  onUpdate,
-}) => {
-  const handleOperatorChange = (operator: 'and' | 'or') => {
+    const newPolicies = [...policy.subPolicies];
+    const [movedPolicy] = newPolicies.splice(fromIndex, 1);
+    newPolicies.splice(toIndex, 0, movedPolicy);
+
     onUpdate({
       ...policy,
-      operator,
+      subPolicies: newPolicies,
+      policyOrder: newPolicies.map(p => p.name)
     });
   };
 
@@ -25,59 +28,113 @@ export const CompositePolicyEditor: React.FC<CompositePolicyEditorProps> = ({
     onUpdate({
       ...policy,
       subPolicies: [...policy.subPolicies, newPolicy],
+      policyOrder: [...(policy.policyOrder || []), newPolicy.name]
     });
   };
 
   const handleUpdateSubPolicy = (index: number, updatedPolicy: Policy) => {
-    const newSubPolicies = [...policy.subPolicies];
-    newSubPolicies[index] = updatedPolicy;
+    const newPolicies = [...policy.subPolicies];
+    const oldName = newPolicies[index].name;
+    newPolicies[index] = updatedPolicy;
+
     onUpdate({
       ...policy,
-      subPolicies: newSubPolicies,
+      subPolicies: newPolicies,
+      policyOrder: (policy.policyOrder || []).map(name => 
+        name === oldName ? updatedPolicy.name : name
+      )
     });
   };
 
   const handleRemoveSubPolicy = (index: number) => {
+    const removedPolicy = policy.subPolicies[index];
     onUpdate({
       ...policy,
       subPolicies: policy.subPolicies.filter((_, i) => i !== index),
+      policyOrder: (policy.policyOrder || []).filter(name => name !== removedPolicy.name)
     });
   };
 
   return (
     <div className="composite-policy-editor">
-      <div className="operator-selector">
-        <label className="form-label">Operator</label>
-        <select
-          value={policy.operator}
-          onChange={(e) => handleOperatorChange(e.target.value as 'and' | 'or')}
-          className="form-input"
-        >
-          <option value="and">AND</option>
-          <option value="or">OR</option>
-        </select>
+      <div className="config-section">
+        <h3>Basic Configuration</h3>
+        <Input
+          label="Max Total Spans Per Second"
+          type="number"
+          min="0"
+          value={policy.maxTotalSpansPerSecond}
+          onChange={(e) => onUpdate({
+            ...policy,
+            maxTotalSpansPerSecond: Number(e.target.value)
+          })}
+          helpText="Maximum number of spans to process per second (0 for unlimited)"
+        />
       </div>
-      <div className="sub-policies">
-        <h4>Sub Policies</h4>
-        {policy.subPolicies.map((subPolicy, index) => (
-          <PolicyCard
-            key={index}
-            policy={subPolicy}
-            onUpdate={(updatedPolicy) => handleUpdateSubPolicy(index, updatedPolicy)}
-            onRemove={() => handleRemoveSubPolicy(index)}
-          />
-        ))}
+
+      <div className="config-section">
+        <h3>Sub Policies</h3>
+        <div className="policy-order-info">
+          <i className="info-icon">ℹ️</i>
+          <span>Use the arrows to change policy execution order</span>
+        </div>
+
+        <div className="sub-policies">
+          {policy.subPolicies.map((subPolicy, index) => (
+            <div key={subPolicy.name} className="policy-item">
+              <div className="policy-order-controls">
+                <div className="policy-order-number">{index + 1}</div>
+                <div className="order-buttons">
+                  <button
+                    className="order-button"
+                    onClick={() => movePolicy(index, index - 1)}
+                    disabled={index === 0}
+                    title="Move up"
+                  >
+                    ↑
+                  </button>
+                  <button
+                    className="order-button"
+                    onClick={() => movePolicy(index, index + 1)}
+                    disabled={index === policy.subPolicies.length - 1}
+                    title="Move down"
+                  >
+                    ↓
+                  </button>
+                </div>
+              </div>
+              <div className="policy-content">
+                <PolicyCard
+                  policy={subPolicy}
+                  onUpdate={(updatedPolicy) => handleUpdateSubPolicy(index, updatedPolicy)}
+                  onRemove={() => handleRemoveSubPolicy(index)}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
         <select
-          onChange={(e) => handleAddSubPolicy(e.target.value as PolicyType)}
+          onChange={(e) => {
+            if (e.target.value) {
+              handleAddSubPolicy(e.target.value as PolicyType);
+              e.target.value = '';
+            }
+          }}
           value=""
-          className="form-input"
+          className="form-input add-policy-select"
         >
-          <option value="" disabled>Add Sub Policy</option>
+          <option value="">Add Sub Policy...</option>
           <option value="numeric_attribute">Numeric Attribute</option>
+          <option value="probabilistic">Probabilistic</option>
+          <option value="rate_limiting">Rate Limiting</option>
+          <option value="status_code">Status Code</option>
           <option value="string_attribute">String Attribute</option>
-          {/* Add other policy types */}
+          <option value="latency">Latency</option>
+          <option value="always_sample">Always Sample</option>
+          <option value="boolean_attribute">Boolean Attribute</option>
         </select>
       </div>
     </div>
   );
-}; 
+};

--- a/src/components/PolicyEditors/LatencyPolicyEditor.tsx
+++ b/src/components/PolicyEditors/LatencyPolicyEditor.tsx
@@ -11,19 +11,43 @@ export const LatencyPolicyEditor: React.FC<LatencyPolicyEditorProps> = ({
   policy,
   onUpdate,
 }) => {
+  const handleChange = (field: keyof Pick<LatencyPolicy, 'thresholdMs' | 'upperThresholdMs'>, value: number) => {
+    onUpdate({
+      ...policy,
+      [field]: value
+    });
+  };
+
   return (
     <div className="policy-editor">
+      <p className="policy-description">
+        Sample traces based on their latency. Traces with latency between the lower and upper thresholds will be sampled.
+      </p>
+      
       <Input
-        label="Threshold (ms)"
+        label="Lower Threshold (ms)"
         type="number"
         min="0"
         value={policy.thresholdMs}
-        onChange={(e) => onUpdate({
-          ...policy,
-          thresholdMs: Number(e.target.value)
-        })}
-        placeholder="Enter latency threshold in milliseconds"
+        onChange={(e) => handleChange('thresholdMs', Number(e.target.value))}
+        placeholder="Enter minimum latency threshold in milliseconds"
       />
+
+      <Input
+        label="Upper Threshold (ms)"
+        type="number"
+        min={policy.thresholdMs || 0}
+        value={policy.upperThresholdMs}
+        onChange={(e) => handleChange('upperThresholdMs', Number(e.target.value))}
+        placeholder="Enter maximum latency threshold in milliseconds (optional)"
+      />
+
+      {policy.upperThresholdMs !== undefined && 
+       policy.upperThresholdMs <= policy.thresholdMs && (
+        <div className="validation-warning">
+          Upper threshold should be greater than lower threshold
+        </div>
+      )}
     </div>
   );
 }; 

--- a/src/components/PolicyEditors/OttlPolicyEditor.tsx
+++ b/src/components/PolicyEditors/OttlPolicyEditor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { OttlPolicy } from '../../types/PolicyTypes';
 import { Editor } from '@monaco-editor/react';
+import { Input } from '../common/Input';
 
 interface OttlPolicyEditorProps {
   policy: OttlPolicy;
@@ -11,25 +12,137 @@ export const OttlPolicyEditor: React.FC<OttlPolicyEditorProps> = ({
   policy,
   onUpdate,
 }) => {
+  // Helper function to update span conditions
+  const handleSpanConditionUpdate = (index: number, value: string) => {
+    const newConditions = [...(policy.spanConditions || [])];
+    newConditions[index] = value;
+    onUpdate({
+      ...policy,
+      spanConditions: newConditions,
+    });
+  };
+
+  // Helper function to update span event conditions
+  const handleSpanEventConditionUpdate = (index: number, value: string) => {
+    const newConditions = [...(policy.spanEventConditions || [])];
+    newConditions[index] = value;
+    onUpdate({
+      ...policy,
+      spanEventConditions: newConditions,
+    });
+  };
+
+  // Add new condition handlers
+  const handleAddSpanCondition = () => {
+    onUpdate({
+      ...policy,
+      spanConditions: [...(policy.spanConditions || []), ''],
+    });
+  };
+
+  const handleAddSpanEventCondition = () => {
+    onUpdate({
+      ...policy,
+      spanEventConditions: [...(policy.spanEventConditions || []), ''],
+    });
+  };
+
+  // Remove condition handlers
+  const handleRemoveSpanCondition = (index: number) => {
+    onUpdate({
+      ...policy,
+      spanConditions: (policy.spanConditions || []).filter((_, i) => i !== index),
+    });
+  };
+
+  const handleRemoveSpanEventCondition = (index: number) => {
+    onUpdate({
+      ...policy,
+      spanEventConditions: (policy.spanEventConditions || []).filter((_, i) => i !== index),
+    });
+  };
+
   return (
     <div className="policy-editor">
-      <label className="form-label">ottl_condition Expression</label>
-      <div className="ottl_condition-editor">
-        <Editor
-          height="200px"
-          defaultLanguage="plaintext"
-          value={policy.expression}
-          onChange={(value) => onUpdate({
+      <div className="form-field">
+        <label className="form-label">Error Mode</label>
+        <select
+          className="form-input"
+          value={policy.errorMode || 'ignore'}
+          onChange={(e) => onUpdate({
             ...policy,
-            expression: value || ''
+            errorMode: e.target.value,
           })}
-          options={{
-            minimap: { enabled: false },
-            scrollBeyondLastLine: false,
-            wordWrap: 'on',
-            theme: 'vs-light',
-          }}
-        />
+        >
+          <option value="ignore">Ignore</option>
+          <option value="propagate">Propagate</option>
+        </select>
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Span Conditions</label>
+        {(policy.spanConditions || []).map((condition, index) => (
+          <div key={index} className="condition-item">
+            <Editor
+              height="100px"
+              defaultLanguage="plaintext"
+              value={condition}
+              onChange={(value) => handleSpanConditionUpdate(index, value || '')}
+              options={{
+                minimap: { enabled: false },
+                scrollBeyondLastLine: false,
+                wordWrap: 'on',
+                theme: 'vs-light',
+              }}
+            />
+            <button
+              className="remove-button"
+              onClick={() => handleRemoveSpanCondition(index)}
+              aria-label="Remove condition"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        <button
+          className="add-button"
+          onClick={handleAddSpanCondition}
+        >
+          Add Span Condition
+        </button>
+      </div>
+
+      <div className="form-field">
+        <label className="form-label">Span Event Conditions</label>
+        {(policy.spanEventConditions || []).map((condition, index) => (
+          <div key={index} className="condition-item">
+            <Editor
+              height="100px"
+              defaultLanguage="plaintext"
+              value={condition}
+              onChange={(value) => handleSpanEventConditionUpdate(index, value || '')}
+              options={{
+                minimap: { enabled: false },
+                scrollBeyondLastLine: false,
+                wordWrap: 'on',
+                theme: 'vs-light',
+              }}
+            />
+            <button
+              className="remove-button"
+              onClick={() => handleRemoveSpanEventCondition(index)}
+              aria-label="Remove condition"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        <button
+          className="add-button"
+          onClick={handleAddSpanEventCondition}
+        >
+          Add Span Event Condition
+        </button>
       </div>
     </div>
   );

--- a/src/components/PolicyEditors/PolicyEditors.css
+++ b/src/components/PolicyEditors/PolicyEditors.css
@@ -16,6 +16,12 @@
   align-items: center;
   gap: 8px;
   cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
 }
 
 .ottl_condition-editor {
@@ -25,28 +31,31 @@
 }
 
 .form-field {
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 .form-label {
   display: block;
   margin-bottom: 8px;
+  font-size: 13px;
   font-weight: 500;
-  color: #1d1d1f;
+  color: #57606a;
 }
 
 .form-input {
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid #d1d1d6;
-  border-radius: 6px;
+  padding: 10px 14px;
+  border: 1px solid #eaecef;
+  border-radius: 8px;
   font-size: 14px;
+  transition: all 0.2s ease;
+  background: #ffffff;
 }
 
 .form-input:focus {
   outline: none;
-  border-color: #0071e3;
-  box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.2);
+  border-color: #0969da;
+  box-shadow: 0 0 0 3px rgba(9, 105, 218, 0.1);
 }
 
 .tag-values,
@@ -62,40 +71,39 @@
   margin-bottom: 8px;
 }
 
-.remove-button {
-  padding: 8px;
-  background: #ff3b30;
-  color: white;
-  border: none;
-  border-radius: 6px;
+.set-remove-button {
+  padding: 6px 12px;
+  background: transparent;
+  color: #57606a;
+  border: 1px solid #eaecef;
+  border-radius: 8px;
   cursor: pointer;
-  font-size: 14px;
-  line-height: 1;
-  min-width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  font-size: 13px;
+}
+
+.remove-button:hover {
+  background: #f8f9fa;
+  color: #cf222e;
 }
 
 .add-button {
   padding: 8px 16px;
-  background: #007aff;
+  background: #0969da;
   color: white;
   border: none;
-  border-radius: 6px;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 14px;
-  margin-top: 8px;
+  font-weight: 500;
+  transition: all 0.2s ease;
 }
 
-.add-button:hover,
-.remove-button:hover {
-  opacity: 0.9;
+.add-button:hover {
+  background: #0860c7;
+  transform: translateY(-1px);
 }
 
-.add-button:active,
-.remove-button:active {
+.add-button:active {
   opacity: 0.8;
 }
 
@@ -113,4 +121,86 @@
   color: #ff3b30;
   font-size: 12px;
   margin-top: 4px;
-} 
+}
+
+.condition-item {
+  margin-bottom: 16px;
+  border: 1px solid #eaecef;
+  border-radius: 6px;
+  padding: 12px;
+  background: #f6f8fa;
+}
+
+.condition-item .monaco-editor {
+  margin-bottom: 8px;
+  border: 1px solid #eaecef;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.condition-item .remove-button {
+  padding: 6px 12px;
+  background: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.condition-item .remove-button:hover {
+  background: #c82333;
+}
+
+.add-button {
+  padding: 8px 16px;
+  background: #0366d6;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  margin-top: 8px;
+}
+
+.add-button:hover {
+  background: #0256b4;
+}
+
+.form-field select.form-input {
+  height: 38px;
+  padding: 6px 12px;
+  background-image: url("data:image/svg+xml,...");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 10px;
+  padding-right: 30px;
+}
+
+.help-text {
+  font-size: 12px;
+  color: #666;
+  margin-top: 4px;
+  margin-left: 24px;
+}
+
+.cache-size-input {
+  margin-top: 8px;
+}
+
+.attribute-values {
+  margin-top: 16px;
+}
+
+.value-item {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.value-item .form-field {
+  flex: 1;
+  margin-bottom: 0;
+}
+  

--- a/src/components/PolicyEditors/StringAttributePolicyEditor.css
+++ b/src/components/PolicyEditors/StringAttributePolicyEditor.css
@@ -1,0 +1,160 @@
+.string-attribute-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.config-section {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.config-section h3 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1a1a1a;
+  margin: 0 0 16px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.matching-options {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.toggle-option {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.toggle-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 500;
+}
+
+.toggle-header input[type="checkbox"] {
+  width: 40px;
+  height: 20px;
+  appearance: none;
+  background: #e4e4e7;
+  border-radius: 20px;
+  position: relative;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.toggle-header input[type="checkbox"]:checked {
+  background: #3b82f6;
+}
+
+.toggle-header input[type="checkbox"]::before {
+  content: '';
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  top: 2px;
+  left: 2px;
+  background: white;
+  transition: all 0.3s ease;
+}
+
+.toggle-header input[type="checkbox"]:checked::before {
+  left: 22px;
+}
+
+.option-description {
+  font-size: 13px;
+  color: #666;
+}
+
+.cache-config {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.values-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.value-item {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.add-value-button {
+  padding: 4px 12px;
+  font-size: 13px;
+  color: #3b82f6;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.add-value-button:hover {
+  background: #dbeafe;
+  border-color: #93c5fd;
+}
+
+.remove-value-button {
+  padding: 4px 8px;
+  font-size: 18px;
+  color: #666;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.remove-value-button:hover {
+  color: #ef4444;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px;
+  color: #666;
+  background: #f9fafb;
+  border-radius: 6px;
+  border: 1px dashed #e5e7eb;
+}
+
+/* Update Input component styles */
+.input-container {
+  flex: 1;
+}
+
+.input-container input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 14px;
+  transition: all 0.2s ease;
+}
+
+.input-container input:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+}
+
+.help-text {
+  font-size: 13px;
+  color: #666;
+  margin-top: 4px;
+} 

--- a/src/components/PolicyEditors/StringAttributePolicyEditor.tsx
+++ b/src/components/PolicyEditors/StringAttributePolicyEditor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StringAttributePolicy } from '../../types/PolicyTypes';
 import { Input } from '../common/Input';
+import './StringAttributePolicyEditor.css';
 
 interface StringAttributePolicyEditorProps {
   policy: StringAttributePolicy;
@@ -11,63 +12,128 @@ export const StringAttributePolicyEditor: React.FC<StringAttributePolicyEditorPr
   policy,
   onUpdate,
 }) => {
-  const handleAddValue = () => {
-    onUpdate({
-      ...policy,
-      values: [...policy.values, '']
-    });
-  };
-
-  const handleUpdateValue = (index: number, value: string) => {
-    const newValues = [...policy.values];
-    newValues[index] = value;
-    onUpdate({
-      ...policy,
-      values: newValues
-    });
-  };
-
-  const handleRemoveValue = (index: number) => {
-    onUpdate({
-      ...policy,
-      values: policy.values.filter((_, i) => i !== index)
-    });
+  // Helper function to update any policy field
+  const updateField = <K extends keyof StringAttributePolicy>(
+    field: K,
+    value: StringAttributePolicy[K]
+  ) => {
+    onUpdate({ ...policy, [field]: value });
   };
 
   return (
-    <div className="policy-editor">
-      <Input
-        label="Key"
-        value={policy.key}
-        onChange={(e) => onUpdate({
-          ...policy,
-          key: e.target.value
-        })}
-        placeholder="Enter attribute key"
-      />
-      <div className="values-list">
-        <label className="form-label">Values</label>
-        {policy.values.map((value, index) => (
-          <div key={index} className="value-item">
+    <div className="policy-editor string-attribute-editor">
+      {/* Main Configuration Section */}
+      <div className="config-section">
+        <h3>Basic Configuration</h3>
+        <Input
+          label="Attribute Key"
+          value={policy.key}
+          onChange={(e) => updateField('key', e.target.value)}
+          placeholder="e.g., http.method, user.id"
+          helpText="The attribute key to match against"
+        />
+      </div>
+
+      {/* Matching Options Section */}
+      <div className="config-section">
+        <h3>Matching Options</h3>
+        <div className="matching-options">
+          <label className="toggle-option">
+            <div className="toggle-header">
+              <span>Use Regular Expressions</span>
+              <input
+                type="checkbox"
+                checked={policy.enabledRegexMatching}
+                onChange={(e) => {
+                  updateField('enabledRegexMatching', e.target.checked);
+                  if (e.target.checked && !policy.cacheMaxSize) {
+                    updateField('cacheMaxSize', 10000); // Default cache size
+                  }
+                }}
+              />
+            </div>
+            <span className="option-description">
+              Enable to use regex patterns instead of exact matching
+            </span>
+          </label>
+
+          <label className="toggle-option">
+            <div className="toggle-header">
+              <span>Invert Match</span>
+              <input
+                type="checkbox"
+                checked={policy.invertMatch}
+                onChange={(e) => updateField('invertMatch', e.target.checked)}
+              />
+            </div>
+            <span className="option-description">
+              Sample traces that don't match the specified values
+            </span>
+          </label>
+        </div>
+
+        {policy.enabledRegexMatching && (
+          <div className="cache-config">
             <Input
-              value={value}
-              onChange={(e) => handleUpdateValue(index, e.target.value)}
-              placeholder="Enter value"
+              label="Cache Size"
+              type="number"
+              min="1000"
+              step="1000"
+              value={policy.cacheMaxSize}
+              onChange={(e) => updateField('cacheMaxSize', Number(e.target.value))}
+              helpText="Number of regex results to cache (recommended: 10000)"
             />
-            <button 
-              className="remove-button"
-              onClick={() => handleRemoveValue(index)}
-            >
-              Remove
-            </button>
           </div>
-        ))}
-        <button 
-          className="add-button"
-          onClick={handleAddValue}
-        >
-          Add Value
-        </button>
+        )}
+      </div>
+
+      {/* Values Section */}
+      <div className="config-section">
+        <h3>
+          {policy.enabledRegexMatching ? 'Regex Patterns' : 'Match Values'}
+          <button
+            className="add-value-button"
+            onClick={() => updateField('values', [...policy.values, ''])}
+          >
+            Add {policy.enabledRegexMatching ? 'Pattern' : 'Value'}
+          </button>
+        </h3>
+        
+        {policy.values.length === 0 ? (
+          <div className="empty-state">
+            No {policy.enabledRegexMatching ? 'patterns' : 'values'} added yet.
+            Click the button above to add one.
+          </div>
+        ) : (
+          <div className="values-list">
+            {policy.values.map((value, index) => (
+              <div key={index} className="value-item">
+                <Input
+                  value={value}
+                  onChange={(e) => {
+                    const newValues = [...policy.values];
+                    newValues[index] = e.target.value;
+                    updateField('values', newValues);
+                  }}
+                  placeholder={policy.enabledRegexMatching ? 
+                    "e.g., ^api\\..*" : 
+                    "e.g., GET, POST"
+                  }
+                />
+                <button
+                  className="remove-value-button"
+                  onClick={() => {
+                    const newValues = policy.values.filter((_, i) => i !== index);
+                    updateField('values', newValues);
+                  }}
+                  aria-label="Remove value"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/PolicySets/PolicySetsMenu.css
+++ b/src/components/PolicySets/PolicySetsMenu.css
@@ -1,0 +1,164 @@
+.policy-sets-menu {
+  position: fixed;
+  left: 0;
+  top: 80px;
+  bottom: 0;
+  background: white;
+  box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, 
+              rgba(15, 15, 15, 0.1) 0px 3px 6px;
+  z-index: 100;
+  width: 240px;
+  transform: translateX(-100%);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border-radius: 8px;
+}
+
+.policy-sets-menu.expanded {
+  transform: translateX(0);
+}
+
+.toggle-button {
+  position: absolute;
+  right: -24px;
+  top: 20px;
+  width: 24px;
+  height: 32px;
+  background: white;
+  border: none;
+  border-radius: 0 3px 3px 0;
+  box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, 
+              rgba(15, 15, 15, 0.1) 0px 3px 6px;
+  cursor: pointer;
+  color: rgb(55, 53, 47);
+  font-size: 14px;
+}
+
+.toggle-button .arrow {
+  transition: transform 0.3s ease-in-out;
+}
+
+.policy-sets-menu.expanded .toggle-button .arrow {
+  transform: rotate(180deg);
+}
+
+.menu-content {
+  height: 100%;
+  overflow-y: auto;
+  padding: 20px;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.policy-sets-menu.expanded .menu-content {
+  opacity: 1;
+  transition-delay: 0.1s;
+}
+
+/* Adjust main content padding when menu is expanded */
+.config-editor {
+  padding-left: 0;
+  transition: padding-left 0.3s ease-in-out;
+}
+
+.config-editor.menu-expanded {
+  padding-left: 300px;
+}
+
+.policy-set-item {
+  padding: 8px 12px;
+  border-radius: 3px;
+  margin-bottom: 4px;
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  transition: background 20ms ease-in 0s;
+}
+
+.policy-set-item:hover {
+  background: rgba(55, 53, 47, 0.03);
+}
+
+.policy-set-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.policy-set-info h4 {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgb(55, 53, 47);
+  margin: 0;
+}
+
+.policy-count {
+  font-size: 12px;
+  color: #666;
+  background: #f2f2f7;
+  padding: 2px 8px;
+  border-radius: 12px;
+}
+
+.policy-set-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.import-button {
+    padding: 4px;
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.set-remove-button {
+  padding: 4px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.import-button:hover,
+.remove-button:hover {
+  opacity: 0.9;
+}
+
+.toggle-button.hidden {
+  display: none;
+}
+
+.menu-header {
+  margin-top: 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.close-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
+  padding: 4px 8px;
+  color: rgba(55, 53, 47, 0.45);
+  transition: color 0.2s ease;
+}
+
+.close-button:hover {
+  color: rgba(55, 53, 47, 0.7);
+}

--- a/src/components/PolicySets/PolicySetsMenu.tsx
+++ b/src/components/PolicySets/PolicySetsMenu.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { usePolicySets } from '../../context/PolicySetsContext';
+import './PolicySetsMenu.css';
+import { Policy } from '../../types/PolicyTypes';
+
+interface PolicySetsMenuProps {
+  onImportPolicies: (policies: Policy[]) => void;
+}
+
+export const PolicySetsMenu: React.FC<PolicySetsMenuProps> = ({ onImportPolicies }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { policySets, removePolicySet } = usePolicySets();
+
+  return (
+    <div className={`policy-sets-menu ${isExpanded ? 'expanded' : ''}`}>
+      <button 
+        className={`toggle-button ${isExpanded ? 'hidden' : ''}`}
+        onClick={() => setIsExpanded(true)}
+        aria-label="Expand menu"
+      >
+        <span className="arrow">→</span>
+      </button>
+      
+      <div className="menu-content">
+        {isExpanded && (
+          <button 
+            className="close-button"
+            onClick={() => setIsExpanded(false)}
+            aria-label="Close menu"
+          >
+            ✕
+          </button>
+        )}
+        <div className="menu-header">
+          <h3>Saved Policy Sets</h3>
+        </div>
+        <div className="policy-sets-list">
+          {policySets.map((set) => (
+            <div key={set.id} className="policy-set-item">
+              <div className="policy-set-info">
+                <h4>{set.name}</h4>
+                <span className="policy-count">
+                  {set.policies.length} {set.policies.length === 1 ? 'policy' : 'policies'}
+                </span>
+              </div>
+              <div className="policy-set-actions">
+                <button
+                  className="import-button"
+                  onClick={() => onImportPolicies(set.policies)}
+                >
+                  +
+                </button>
+                <button
+                  className="set-remove-button"
+                  onClick={() => removePolicySet(set.id)}
+                  aria-label="Remove policy set"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/common/AddPolicyButton.css
+++ b/src/components/common/AddPolicyButton.css
@@ -3,20 +3,21 @@
 }
 
 .add-policy-button {
-  padding: 8px 16px;
-  background: #007aff;
-  color: white;
-  border: none;
-  border-radius: 6px;
+  padding: 6px 12px;
+  background: transparent;
+  color: rgb(55, 53, 47);
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 3px;
   cursor: pointer;
   font-size: 14px;
   display: flex;
   align-items: center;
   gap: 8px;
+  transition: background 20ms ease-in 0s;
 }
 
 .add-policy-button:hover {
-  background: #0066cc;
+  background: rgba(55, 53, 47, 0.08);
 }
 
 .policy-dropdown {
@@ -25,25 +26,27 @@
   right: 0;
   margin-top: 4px;
   background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  border-radius: 3px;
+  box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, 
+              rgba(15, 15, 15, 0.1) 0px 3px 6px, 
+              rgba(15, 15, 15, 0.2) 0px 9px 24px;
   z-index: 1000;
   min-width: 200px;
-  max-height: 400px;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .policy-dropdown-item {
   width: 100%;
-  padding: 8px 16px;
+  padding: 6px 12px;
   border: none;
   background: none;
   text-align: left;
   cursor: pointer;
   font-size: 14px;
-  color: #1d1d1f;
+  color: rgb(55, 53, 47);
+  transition: background 20ms ease-in 0s;
 }
 
 .policy-dropdown-item:hover {
-  background: #f5f5f7;
+  background: rgba(55, 53, 47, 0.08);
 } 

--- a/src/components/common/AddPolicyButton.tsx
+++ b/src/components/common/AddPolicyButton.tsx
@@ -23,7 +23,8 @@ export const AddPolicyButton: React.FC<AddPolicyButtonProps> = ({ onSelectPolicy
     { type: 'ottl_condition', label: 'ottl_condition' },
     { type: 'span_count', label: 'Span Count' },
     { type: 'string_attribute', label: 'String Tag' },
-    { type: 'trace_state', label: 'Trace State' }
+    { type: 'trace_state', label: 'Trace State' },
+    { type: 'and', label: 'And' }
   ];
 
   useEffect(() => {

--- a/src/components/common/EditableTitle.css
+++ b/src/components/common/EditableTitle.css
@@ -1,0 +1,17 @@
+.policy-name-text {
+  font-size: 16px;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: text;
+  color: #1d1d1f;
+}
+
+.policy-name-text:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.policy-name-text:empty::before {
+  content: attr(placeholder);
+  color: #8e8e93;
+} 

--- a/src/components/common/EditableTitle.tsx
+++ b/src/components/common/EditableTitle.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import './EditableTitle.css';
+
+interface EditableTitleProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+}
+
+export const EditableTitle: React.FC<EditableTitleProps> = ({
+  value,
+  onChange,
+  placeholder,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleBlur = () => {
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      setIsEditing(false);
+    }
+  };
+
+  return isEditing ? (
+    <input
+      type="text"
+      className="policy-name-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+      placeholder={placeholder}
+      autoFocus
+    />
+  ) : (
+    <span 
+      className="policy-name-text"
+      onClick={handleClick}
+    >
+      {value || placeholder}
+    </span>
+  );
+}; 

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  helpText?: string;
 }
 
 export const Input: React.FC<InputProps> = ({ label, error, className, ...props }) => {

--- a/src/context/PolicySetsContext.tsx
+++ b/src/context/PolicySetsContext.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { Policy, PolicySet } from '../types/PolicyTypes';
+
+interface PolicySetsContextType {
+  policySets: PolicySet[];
+  addPolicySet: (name: string, policies: Policy[]) => void;
+  removePolicySet: (id: string) => void;
+  importPolicySet: (policySet: PolicySet) => void;
+}
+
+const PolicySetsContext = createContext<PolicySetsContextType | undefined>(undefined);
+
+export const PolicySetsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [policySets, setPolicySets] = useState<PolicySet[]>(() => {
+    const saved = localStorage.getItem('policySets');
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('policySets', JSON.stringify(policySets));
+  }, [policySets]);
+
+  const addPolicySet = (name: string, policies: Policy[]) => {
+    const newPolicySet: PolicySet = {
+      id: Date.now().toString(),
+      name,
+      policies,
+      createdAt: new Date().toISOString(),
+    };
+    setPolicySets([...policySets, newPolicySet]);
+  };
+
+  const removePolicySet = (id: string) => {
+    setPolicySets(policySets.filter(set => set.id !== id));
+  };
+
+  const importPolicySet = (policySet: PolicySet) => {
+    setPolicySets([...policySets, { ...policySet, id: Date.now().toString() }]);
+  };
+
+  return (
+    <PolicySetsContext.Provider value={{ policySets, addPolicySet, removePolicySet, importPolicySet }}>
+      {children}
+    </PolicySetsContext.Provider>
+  );
+};
+
+export const usePolicySets = () => {
+  const context = useContext(PolicySetsContext);
+  if (!context) {
+    throw new Error('usePolicySets must be used within a PolicySetsProvider');
+  }
+  return context;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,14 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: inter, -apple-system, BlinkMacSystemFont, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f7;
+  background-color: #fafafa;
+  color: #2c3338;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 code {

--- a/src/types/PolicyTypes.ts
+++ b/src/types/PolicyTypes.ts
@@ -25,11 +25,13 @@ export interface NumericTagPolicy extends BasePolicy {
   key: string;
   minValue: number;
   maxValue: number;
+  invertMatch?: boolean;
 }
 
 export interface ProbabilisticPolicy extends BasePolicy {
   type: 'probabilistic';
   samplingPercentage: number;
+  hashSalt?: string;
 }
 
 export interface RateLimitingPolicy extends BasePolicy {
@@ -46,11 +48,15 @@ export interface StringAttributePolicy extends BasePolicy {
   type: 'string_attribute';
   key: string;
   values: string[];
+  enabledRegexMatching?: boolean;
+  cacheMaxSize?: number;
+  invertMatch?: boolean;
 }
 
 export interface LatencyPolicy extends BasePolicy {
   type: 'latency';
   thresholdMs: number;
+  upperThresholdMs?: number;
 }
 
 export interface AlwaysSamplePolicy extends BasePolicy {
@@ -61,24 +67,26 @@ export interface BooleanTagPolicy extends BasePolicy {
   type: 'boolean_attribute';
   key: string;
   value: boolean;
+  invertMatch?: boolean;
 }
 
 export interface CompositePolicy extends BasePolicy {
   type: 'composite';
+  maxTotalSpansPerSecond?: number;
+  policyOrder?: string[];
+  rateAllocation?: Array<{
+    policy: string;
+    percent: number;
+  }>;
   subPolicies: Policy[];
   operator: 'and' | 'or';
 }
 
-export interface NumericTagPolicy extends BasePolicy {
-  type: 'numeric_attribute';
-  key: string;
-  minValue: number;
-  maxValue: number;
-}
-
 export interface OttlPolicy extends BasePolicy {
   type: 'ottl_condition';
-  expression: string;
+  errorMode?: string;
+  spanConditions?: string[];
+  spanEventConditions?: string[];
 }
 
 export interface SpanCountPolicy extends BasePolicy {
@@ -120,3 +128,10 @@ export type Policy =
   | StringTagPolicy
   | TraceStatePolicy
   | AndPolicy;
+
+export interface PolicySet {
+  id: string;
+  name: string;
+  policies: Policy[];
+  createdAt: string;
+}

--- a/src/utils/policyUtils.ts
+++ b/src/utils/policyUtils.ts
@@ -39,12 +39,15 @@ export const createNewPolicy = (type: PolicyType): Policy => {
         type: 'string_attribute',
         key: '',
         values: [],
+        enabledRegexMatching: false,
+        cacheMaxSize: undefined,
+        invertMatch: false,
       };
     case 'latency':
       return {
         ...basePolicy,
         type: 'latency',
-        thresholdMs: 1000,
+        thresholdMs: 1000
       };
     case 'always_sample':
       return {
@@ -77,7 +80,9 @@ export const createNewPolicy = (type: PolicyType): Policy => {
       return {
         ...basePolicy,
         type: 'ottl_condition',
-        expression: '',
+        spanConditions: [],
+        spanEventConditions: [],
+        errorMode: 'ignore',
       };
     case 'span_count':
       return {
@@ -92,6 +97,9 @@ export const createNewPolicy = (type: PolicyType): Policy => {
         type: 'string_attribute',
         key: '',
         values: [],
+        enabledRegexMatching: false,
+        cacheMaxSize: undefined,
+        invertMatch: false,
       };
     case 'trace_state':
       return {


### PR DESCRIPTION
This PR introduces a new Policy Sets management system for saving and reusing configurations
and aligns our tail sampling configuration with the official otel implementation by adding missing fields and 

### New Feature: Policy Sets Management
- Added a new sidebar for managing saved policy sets
- Implemented policy set storage and retrieval functionality
- Added ability to:
  - Save current configuration as a named policy set
  - Load existing policy sets
  - Delete saved policy sets

### Policy Type Definitions
- Added `upperThresholdMs` to Latency Policy
- Added regex matching support to String Attribute Policy (`enabledRegexMatching`, `cacheMaxSize`, `invertMatch`)
- Added `maxTotalSpansPerSecond`, `policyOrder`, and `rateAllocation` to Composite Policy
