### PR TITLE
feat: Lawrence link

### DIFF
--- a/otail-web/public/lawrence.svg
+++ b/otail-web/public/lawrence.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="black"/>
+  <polygon points="8,24 8,8 12,8 12,20 20,20 20,24" fill="white"/>
+  <circle cx="22" cy="10" r="2" fill="white"/>
+</svg>

--- a/otail-web/src/components/layout/app-sidebar.tsx
+++ b/otail-web/src/components/layout/app-sidebar.tsx
@@ -92,7 +92,7 @@ export function AppSidebar({ noBackend = false }: AppSidebarProps) {
 
   return (
     <Sidebar collapsible="icon" className="border-r border-border">
-      <SidebarHeader className="border-b border-border h-16 flex items-center justify-center relative">
+      <SidebarHeader className="border-b border-border h-14 flex items-center justify-center relative">
         <SidebarMenu>
           <SidebarMenuItem>
             {state === "collapsed" ? (
@@ -159,6 +159,34 @@ export function AppSidebar({ noBackend = false }: AppSidebarProps) {
 
         <div className="px-4 pb-4 border-border">
           <Checklist mode={state === "expanded" ? "full" : "compact"} />
+        </div>
+
+        {/* Lawrence attribution */}
+        <div className="px-4 pb-2">
+          <a
+            href="https://getlawrence.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              "flex items-center justify-center transition-opacity hover:opacity-80",
+              state === "expanded" ? "gap-2" : "justify-center"
+            )}
+            title="Brought to you by Lawrence"
+          >
+            <img 
+              src="/lawrence.svg" 
+              alt="Lawrence" 
+              className={cn(
+                "transition-all",
+                state === "expanded" ? "w-5 h-5" : "w-4 h-4"
+              )}
+            />
+            {state === "expanded" && (
+              <span className="text-xs text-muted-foreground hover:text-primary transition-colors">
+                Brought to you by Lawrence
+              </span>
+            )}
+          </a>
         </div>
 
         <div className="mt-auto border-t border-border">

--- a/otail-web/src/layout.tsx
+++ b/otail-web/src/layout.tsx
@@ -26,10 +26,30 @@ export default function Layout() {
           <AgentConfigBanner />
           <ActivePipelineBanner />
         </header>
-        <div className="flex flex-1 flex-col w-full h-[calc(100vh-3.5rem)] min-h-0 overflow-hidden">
+        <div className="flex flex-1 flex-col w-full h-[calc(100vh-3.5rem)] min-h-0 overflow-hidden relative">
           <PageLayout>
             <Outlet />
           </PageLayout>
+          
+          {/* Lawrence footer attribution */}
+          <div className="absolute bottom-2 right-4 pointer-events-none">
+            <a
+              href="https://getlawrence.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 transition-opacity hover:opacity-80 pointer-events-auto"
+              title="Brought to you by Lawrence"
+            >
+              <img 
+                src="/lawrence.svg" 
+                alt="Lawrence" 
+                className="w-4 h-4"
+              />
+              <span className="text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+                Lawrence
+              </span>
+            </a>
+          </div>
         </div>
       </SidebarInset>
     </SidebarProvider>


### PR DESCRIPTION
This pull request adds Lawrence attribution to the UI and makes a minor adjustment to the sidebar header height. The Lawrence branding is now visible in both the sidebar and the main layout, improving transparency about the product's origin.

**UI branding updates:**

* Added a Lawrence attribution section with logo and text to the bottom of the sidebar in `app-sidebar.tsx`, which adapts its appearance based on sidebar state.
* Added a Lawrence footer attribution to the main layout, positioned at the bottom-right of the page in `layout.tsx`.

**UI layout adjustment:**

* Reduced the sidebar header height from 16 to 14 units for better alignment in `app-sidebar.tsx`.